### PR TITLE
JNO-1096: enable autoscaling and tweak tables.yml settings

### DIFF
--- a/.convox/app
+++ b/.convox/app
@@ -1,0 +1,1 @@
+console

--- a/formation.json
+++ b/formation.json
@@ -386,7 +386,7 @@
               
               { "Ref": "AWS::NoValue" }
             ],
-            "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" },
+            "ProvisionedThroughput": { "ReadCapacityUnits": "10", "WriteCapacityUnits": "2" },
             "GlobalSecondaryIndexes": [
               
                 {
@@ -397,7 +397,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "10", "WriteCapacityUnits": "2" }
                 },
               
                 {
@@ -408,13 +408,172 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "10", "WriteCapacityUnits": "2" }
                 },
               
               { "Ref": "AWS::NoValue" }
             ]
           }
         },
+        
+          "ConsolePrivateDeployKeysScalableTargetRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "Properties": {
+              "MaxCapacity": 100,
+              "MinCapacity": 10,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateDeployKeysDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateDeployKeysScalableTargetWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "DependsOn": "ConsolePrivateDeployKeysScalableTargetRead",
+            "Properties": {
+              "MaxCapacity": 20,
+              "MinCapacity": 2,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateDeployKeysDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateDeployKeysScalingRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-deploy-keys-scaling-read" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateDeployKeysScalableTargetRead" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+              }
+            }
+          },
+          "ConsolePrivateDeployKeysScalingWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-deploy-keys-scaling-write" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateDeployKeysScalableTargetWrite" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+              }
+            }
+          },
+          
+            "ConsolePrivateDeployKeysIndexKeyHashScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateDeployKeysScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 100,
+                "MinCapacity": 10,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateDeployKeysDynamoDBTable}/index/key-hash-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateDeployKeysIndexKeyHashScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateDeployKeysScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateDeployKeysDynamoDBTable}/index/key-hash-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateDeployKeysIndexKeyHashScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-deploy-keys-index-key-hash-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateDeployKeysIndexKeyHashScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateDeployKeysIndexKeyHashScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-deploy-keys-index-key-hash-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateDeployKeysIndexKeyHashScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateDeployKeysIndexOrganizationIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateDeployKeysScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 100,
+                "MinCapacity": 10,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateDeployKeysDynamoDBTable}/index/organization-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateDeployKeysIndexOrganizationIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateDeployKeysScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateDeployKeysDynamoDBTable}/index/organization-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateDeployKeysIndexOrganizationIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-deploy-keys-index-organization-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateDeployKeysIndexOrganizationIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateDeployKeysIndexOrganizationIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-deploy-keys-index-organization-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateDeployKeysIndexOrganizationIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
         
       
         "ConsolePrivateInstallsDynamoDBTable": {
@@ -502,7 +661,7 @@
               
               { "Ref": "AWS::NoValue" }
             ],
-            "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "2" },
+            "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" },
             "GlobalSecondaryIndexes": [
               
                 {
@@ -513,7 +672,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
                 {
@@ -524,7 +683,7 @@
                     { "AttributeName": "created", "KeyType": "RANGE" },
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
                 {
@@ -535,7 +694,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
                 {
@@ -546,13 +705,278 @@
                     { "AttributeName": "created", "KeyType": "RANGE" },
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "20", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
               { "Ref": "AWS::NoValue" }
             ]
           }
         },
+        
+          "ConsolePrivateJobsScalableTargetRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "Properties": {
+              "MaxCapacity": 20,
+              "MinCapacity": 2,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateJobsScalableTargetWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "DependsOn": "ConsolePrivateJobsScalableTargetRead",
+            "Properties": {
+              "MaxCapacity": 10,
+              "MinCapacity": 1,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateJobsScalingRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-scaling-read" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateJobsScalableTargetRead" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+              }
+            }
+          },
+          "ConsolePrivateJobsScalingWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-scaling-write" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateJobsScalableTargetWrite" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+              }
+            }
+          },
+          
+            "ConsolePrivateJobsIndexCreatedScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/created-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexCreatedScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/created-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexCreatedScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-created-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexCreatedScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateJobsIndexCreatedScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-created-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexCreatedScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateJobsIndexJobCreatedOrgScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/job-created-org-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexJobCreatedOrgScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/job-created-org-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexJobCreatedOrgScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-job-created-org-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexJobCreatedOrgScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateJobsIndexJobCreatedOrgScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-job-created-org-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexJobCreatedOrgScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateJobsIndexOrganizationIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/organization-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexOrganizationIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/organization-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexOrganizationIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-organization-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexOrganizationIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateJobsIndexOrganizationIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-organization-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexOrganizationIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateJobsIndexWorkflowIdCreatedScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/workflow-id-created-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexWorkflowIdCreatedScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateJobsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateJobsDynamoDBTable}/index/workflow-id-created-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateJobsIndexWorkflowIdCreatedScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-workflow-id-created-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexWorkflowIdCreatedScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateJobsIndexWorkflowIdCreatedScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-jobs-index-workflow-id-created-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateJobsIndexWorkflowIdCreatedScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
         
       
         "ConsolePrivateOrganizationInvitesDynamoDBTable": {
@@ -637,7 +1061,7 @@
               { "AttributeName": "user-id", "KeyType": "RANGE" },
               { "Ref": "AWS::NoValue" }
             ],
-            "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" },
+            "ProvisionedThroughput": { "ReadCapacityUnits": "3", "WriteCapacityUnits": "1" },
             "GlobalSecondaryIndexes": [
               
                 {
@@ -648,13 +1072,119 @@
                     { "AttributeName": "organization-id", "KeyType": "RANGE" },
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "3", "WriteCapacityUnits": "1" }
                 },
               
               { "Ref": "AWS::NoValue" }
             ]
           }
         },
+        
+          "ConsolePrivateOrganizationMembershipsScalableTargetRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "Properties": {
+              "MaxCapacity": 30,
+              "MinCapacity": 3,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationMembershipsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateOrganizationMembershipsScalableTargetWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "DependsOn": "ConsolePrivateOrganizationMembershipsScalableTargetRead",
+            "Properties": {
+              "MaxCapacity": 10,
+              "MinCapacity": 1,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationMembershipsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateOrganizationMembershipsScalingRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-organization-memberships-scaling-read" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationMembershipsScalableTargetRead" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+              }
+            }
+          },
+          "ConsolePrivateOrganizationMembershipsScalingWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-organization-memberships-scaling-write" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationMembershipsScalableTargetWrite" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+              }
+            }
+          },
+          
+            "ConsolePrivateOrganizationMembershipsIndexUserIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateOrganizationMembershipsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 30,
+                "MinCapacity": 3,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationMembershipsDynamoDBTable}/index/user-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateOrganizationMembershipsIndexUserIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateOrganizationMembershipsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationMembershipsDynamoDBTable}/index/user-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateOrganizationMembershipsIndexUserIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-organization-memberships-index-user-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationMembershipsIndexUserIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateOrganizationMembershipsIndexUserIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-organization-memberships-index-user-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationMembershipsIndexUserIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
         
       
         "ConsolePrivateOrganizationsDynamoDBTable": {
@@ -675,7 +1205,7 @@
               
               { "Ref": "AWS::NoValue" }
             ],
-            "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" },
+            "ProvisionedThroughput": { "ReadCapacityUnits": "3", "WriteCapacityUnits": "1" },
             "GlobalSecondaryIndexes": [
               
                 {
@@ -686,13 +1216,119 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "3", "WriteCapacityUnits": "1" }
                 },
               
               { "Ref": "AWS::NoValue" }
             ]
           }
         },
+        
+          "ConsolePrivateOrganizationsScalableTargetRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "Properties": {
+              "MaxCapacity": 30,
+              "MinCapacity": 3,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateOrganizationsScalableTargetWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "DependsOn": "ConsolePrivateOrganizationsScalableTargetRead",
+            "Properties": {
+              "MaxCapacity": 10,
+              "MinCapacity": 1,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateOrganizationsScalingRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-organizations-scaling-read" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationsScalableTargetRead" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+              }
+            }
+          },
+          "ConsolePrivateOrganizationsScalingWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-organizations-scaling-write" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationsScalableTargetWrite" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+              }
+            }
+          },
+          
+            "ConsolePrivateOrganizationsIndexNameScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateOrganizationsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 30,
+                "MinCapacity": 3,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationsDynamoDBTable}/index/name-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateOrganizationsIndexNameScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateOrganizationsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateOrganizationsDynamoDBTable}/index/name-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateOrganizationsIndexNameScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-organizations-index-name-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationsIndexNameScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateOrganizationsIndexNameScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-organizations-index-name-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateOrganizationsIndexNameScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
         
       
         "ConsolePrivateRacksDynamoDBTable": {
@@ -757,7 +1393,7 @@
               
               { "Ref": "AWS::NoValue" }
             ],
-            "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" },
+            "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" },
             "GlobalSecondaryIndexes": [
               
                 {
@@ -768,7 +1404,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
                 },
               
                 {
@@ -779,7 +1415,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
                 },
               
                 {
@@ -790,7 +1426,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
                 },
               
                 {
@@ -801,13 +1437,278 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "5", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
                 },
               
               { "Ref": "AWS::NoValue" }
             ]
           }
         },
+        
+          "ConsolePrivateUsersScalableTargetRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "Properties": {
+              "MaxCapacity": 20,
+              "MinCapacity": 2,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateUsersScalableTargetWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "DependsOn": "ConsolePrivateUsersScalableTargetRead",
+            "Properties": {
+              "MaxCapacity": 20,
+              "MinCapacity": 2,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateUsersScalingRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-users-scaling-read" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateUsersScalableTargetRead" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+              }
+            }
+          },
+          "ConsolePrivateUsersScalingWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-users-scaling-write" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateUsersScalableTargetWrite" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+              }
+            }
+          },
+          
+            "ConsolePrivateUsersIndexApiKeyHashScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/api-key-hash-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexApiKeyHashScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/api-key-hash-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexApiKeyHashScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-api-key-hash-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexApiKeyHashScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateUsersIndexApiKeyHashScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-api-key-hash-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexApiKeyHashScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateUsersIndexEmailScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/email-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexEmailScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/email-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexEmailScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-email-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexEmailScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateUsersIndexEmailScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-email-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexEmailScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateUsersIndexGithubIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/github-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexGithubIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/github-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexGithubIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-github-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexGithubIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateUsersIndexGithubIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-github-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexGithubIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateUsersIndexPasswordResetTokenScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/password-reset-token-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexPasswordResetTokenScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateUsersScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateUsersDynamoDBTable}/index/password-reset-token-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateUsersIndexPasswordResetTokenScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-password-reset-token-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexPasswordResetTokenScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateUsersIndexPasswordResetTokenScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-users-index-password-reset-token-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateUsersIndexPasswordResetTokenScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
         
       
         "ConsolePrivateWebhooksDynamoDBTable": {
@@ -898,7 +1799,7 @@
               
               { "Ref": "AWS::NoValue" }
             ],
-            "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" },
+            "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" },
             "GlobalSecondaryIndexes": [
               
                 {
@@ -909,7 +1810,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
                 {
@@ -920,7 +1821,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
                 {
@@ -931,7 +1832,7 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
                 {
@@ -942,13 +1843,278 @@
                     
                     { "Ref": "AWS::NoValue" }
                   ],
-                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "2" }
+                  "ProvisionedThroughput": { "ReadCapacityUnits": "2", "WriteCapacityUnits": "1" }
                 },
               
               { "Ref": "AWS::NoValue" }
             ]
           }
         },
+        
+          "ConsolePrivateWorkflowsScalableTargetRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "Properties": {
+              "MaxCapacity": 20,
+              "MinCapacity": 2,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateWorkflowsScalableTargetWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+            "DependsOn": "ConsolePrivateWorkflowsScalableTargetRead",
+            "Properties": {
+              "MaxCapacity": 10,
+              "MinCapacity": 1,
+              "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}" },
+              "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+              "ScalableDimension": "dynamodb:table:WriteCapacityUnits",
+              "ServiceNamespace": "dynamodb"
+            }
+          },
+          "ConsolePrivateWorkflowsScalingRead": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-scaling-read" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsScalableTargetRead" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+              }
+            }
+          },
+          "ConsolePrivateWorkflowsScalingWrite": {
+            "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+            "Properties": {
+              "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-scaling-write" },
+              "PolicyType": "TargetTrackingScaling",
+              "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsScalableTargetWrite" },
+              "TargetTrackingScalingPolicyConfiguration": {
+                "TargetValue": 70.0,
+                "ScaleInCooldown": 300,
+                "ScaleOutCooldown": 1200,
+                "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+              }
+            }
+          },
+          
+            "ConsolePrivateWorkflowsIndexIntegrationIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/integration-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexIntegrationIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/integration-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexIntegrationIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-integration-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexIntegrationIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateWorkflowsIndexIntegrationIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-integration-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexIntegrationIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateWorkflowsIndexNameScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/name-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexNameScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/name-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexNameScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-name-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexNameScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateWorkflowsIndexNameScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-name-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexNameScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateWorkflowsIndexOrganizationIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/organization-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexOrganizationIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/organization-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexOrganizationIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-organization-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexOrganizationIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateWorkflowsIndexOrganizationIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-organization-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexOrganizationIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
+            "ConsolePrivateWorkflowsIndexTriggerIdScalableTargetRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetRead",
+              "Properties": {
+                "MaxCapacity": 20,
+                "MinCapacity": 2,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/trigger-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:ReadCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexTriggerIdScalableTargetWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+              "DependsOn": "ConsolePrivateWorkflowsScalableTargetWrite",
+              "Properties": {
+                "MaxCapacity": 10,
+                "MinCapacity": 1,
+                "ResourceId": { "Fn::Sub": "table/${ConsolePrivateWorkflowsDynamoDBTable}/index/trigger-id-index" },
+                "RoleARN": { "Fn::GetAtt": [ "DynamoScalingRole", "Arn" ] },
+                "ScalableDimension": "dynamodb:index:WriteCapacityUnits",
+                "ServiceNamespace": "dynamodb"
+              }
+            },
+            "ConsolePrivateWorkflowsIndexTriggerIdScalingRead": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-trigger-id-scaling-read" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexTriggerIdScalableTargetRead" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBReadCapacityUtilization" }
+                }
+              }
+            },
+            "ConsolePrivateWorkflowsIndexTriggerIdScalingWrite": {
+              "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+              "Properties": {
+                "PolicyName": { "Fn::Sub": "${TablePrefix}-workflows-index-trigger-id-scaling-write" },
+                "PolicyType": "TargetTrackingScaling",
+                "ScalingTargetId": { "Ref": "ConsolePrivateWorkflowsIndexTriggerIdScalableTargetWrite" },
+                "TargetTrackingScalingPolicyConfiguration": {
+                  "TargetValue": 70.0,
+                  "ScaleInCooldown": 300,
+                  "ScaleOutCooldown": 1200,
+                  "PredefinedMetricSpecification": { "PredefinedMetricType": "DynamoDBWriteCapacityUtilization" }
+                }
+              }
+            },
+          
         
       
       "DynamoScalingRole": {

--- a/tables.yml
+++ b/tables.yml
@@ -5,8 +5,9 @@ audit-logs:
   indexes:
     rack: rack,timestamp
 deploy-keys:
+  autoscale: true
   key: id
-  capacity: 2,2
+  capacity: 10,2
   indexes:
     key-hash: key-hash
     organization-id: organization-id
@@ -19,8 +20,9 @@ integrations:
   indexes:
     organization-id: organization-id
 jobs:
+  autoscale: true
   key: id
-  capacity: 20,2
+  capacity: 2,1
   indexes:
     created: created
     job-created-org: organization-id,created
@@ -34,13 +36,15 @@ organization-invites:
     organization-id: organization-id
     token: token
 organizations:
+  autoscale: true
   key: id
-  capacity: 5,2
+  capacity: 3,1
   indexes:
     name: name
 organization-memberships:
+  autoscale: true
   key: organization-id,user-id
-  capacity: 5,2
+  capacity: 3,1
   indexes:
     user-id: user-id,organization-id
 racks:
@@ -49,8 +53,9 @@ racks:
   indexes:
     organization-id: organization-id
 users:
+  autoscale: true
   key: id
-  capacity: 5,2
+  capacity: 2,2
   indexes:
     api-key-hash: api-key-hash
     email: email
@@ -64,8 +69,9 @@ webhooks:
     integration-id: integration-id
     rack-id: rack-id
 workflows:
+  autoscale: true
   key: id
-  capacity: 2,2
+  capacity: 2,1
   indexes:
     integration-id: integration-id
     name: name


### PR DESCRIPTION
### [JNO-1096](https://waveaccounting.atlassian.net/browse/JNO-1096)

### Notes

* Autoscaling math
  * Min capacity is value from yaml file
  * Max capacity is `min * 10`
  * Autoscaling target is 70% usage
* Non autoscaling
  * Table and index take values from yaml file
* The changes were adapted from our current dynamodb settings for prod console